### PR TITLE
Potential fix for code scanning alert no. 48: Expression injection in Actions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -74,9 +74,11 @@ jobs:
 
       - name: Extract version from commit message
         id: version
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           # Extract version X.Y.Z from commit message like "chore: release vX.Y.Z ..."
-          if [[ "${{ github.event.head_commit.message }}" =~ chore:\ release\ v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+          if [[ "$COMMIT_MESSAGE" =~ chore:\ release\ v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
             VERSION="${BASH_REMATCH[1]}"
             # Basic validation
             if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -88,9 +90,8 @@ jobs:
             fi
           else
             echo "Error: Commit message does not contain 'chore: release vX.Y.Z'." >&2
-            echo "Commit message was: ${{ github.event.head_commit.message }}" >&2
+            echo "Commit message was: $COMMIT_MESSAGE" >&2
             exit 1 # Fail if version not found
-          fi
 
       - name: Build and push Docker image to GHCR
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Potential fix for [https://github.com/thomasvincent/wordpress-gmail-cli/security/code-scanning/48](https://github.com/thomasvincent/wordpress-gmail-cli/security/code-scanning/48)

To fix the problem, we should avoid using the `${{ github.event.head_commit.message }}` directly within the shell script. Instead, we should set the untrusted input value to an intermediate environment variable and then use the environment variable using the native shell syntax. This approach will prevent code injection vulnerabilities.

1. Set the commit message to an environment variable.
2. Use the environment variable within the shell script using native shell syntax.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
