### PR TITLE
chore: bump actions/checkout from v5 to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write # For PR comments
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -111,7 +111,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
@@ -174,7 +174,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Check if Dockerfile exists
         id: check-dockerfile

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/php-security-scan.yml
+++ b/.github/workflows/php-security-scan.yml
@@ -30,7 +30,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Check if composer.json and .php files exist
         id: check_php_files
@@ -112,7 +112,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Check if php files exist
         id: check_php_files
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Check if php files exist
         id: check_php_files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       id-token: write # For SLSA provenance
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         
       - name: Build artifacts
         run: |

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
@@ -42,7 +42,7 @@ jobs:
       security-events: write  # To upload SARIF results
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       # REQUIRED step before building
       - name: Set up Docker Buildx
@@ -96,7 +96,7 @@ jobs:
       security-events: write  # Potentially needed to upload results
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           # Fetch full history for better comparison/scanning
           fetch-depth: 0
@@ -116,7 +116,7 @@ jobs:
       contents: read          # REQUIRED for checkout
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Check if composer.json exists
         id: check_composer

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -66,7 +66,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -99,7 +99,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -132,7 +132,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Summary

This PR updates the `actions/checkout` action from v5 to v6 in all GitHub Actions workflows.

## Changes

- Update `actions/checkout@v5` → `actions/checkout@v6`

## Benefits

- Performance improvements
- Better support for newer GitHub features
- Keeps dependencies up to date
- Security improvements from the latest version

## Testing

The workflows will be automatically tested when this PR is opened. All existing functionality should continue to work as expected since v6 is backward compatible with v5.

## References

- [actions/checkout releases](https://github.com/actions/checkout/releases)
